### PR TITLE
Fixed path for layout templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,9 +125,9 @@ bin/cake bake template [command] -t CakeLte recovery
 Replace the files elements
 
 - Layouts
-  - `src/templates/layout/default.php`
-  - `src/templates/layout/login.php`
-  - `src/templates/layout/top-nav.php`
+  - `templates/plugin/CakeLte/layout/default.php`
+  - `templates/plugin/CakeLte/layout/login.php`
+  - `templates/plugin/CakeLte/layout/top-nav.php`
 - Content
   - `src/templates/element/content/header.php`
 - Header navbar


### PR DESCRIPTION
As described in [CakePHP cookbook](https://book.cakephp.org/4/en/plugins.html#overriding-plugin-templates-from-inside-your-application) I corrected the pathes for the layout templates.