### PR TITLE
Removes deprecation warning on PHP 8.2

### DIFF
--- a/src/Style/StyleTrait.php
+++ b/src/Style/StyleTrait.php
@@ -10,6 +10,7 @@ namespace CakeLte\Style;
 trait StyleTrait
 {
     protected $custom_css_classes = [];
+    protected $_helper;
 
     public function __construct($helper)
     {


### PR DESCRIPTION
This removes deprecation warnings like:
```php
Deprecated (8192) : Creation of dynamic property CakeLte\Style\Header::$_helper is deprecated [in /vendor/arodu/cakelte/src/Style/StyleTrait.php, line 17]
Deprecated (8192) : Creation of dynamic property CakeLte\Style\Sidebar::$_helper is deprecated [in /vendor/arodu/cakelte/src/Style/StyleTrait.php, line 17]
```

I don't know if null is the best initial value tho...